### PR TITLE
fix: preserve level id in generator fallback and update tests

### DIFF
--- a/Project/Sources/Entities/Level.swift
+++ b/Project/Sources/Entities/Level.swift
@@ -63,6 +63,10 @@ struct Level: Codable, Equatable, Identifiable {
 		cellsMatrix.count
 	}
 
+    var isTutorial: Bool {
+        id == 0
+    }
+
     var isCompleted: Bool {
         cellsMatrix.allSatisfy { row in row.allSatisfy { $0 == 1 } }
     }

--- a/Project/Sources/Entities/LevelGenerator.swift
+++ b/Project/Sources/Entities/LevelGenerator.swift
@@ -25,7 +25,7 @@ final class LevelGenerator: ILevelGenerator {
         randomSource: IRandomSource = RandomSource()
     ) -> Level {
         guard id >= 0, size > 0 else {
-            return Level(id: 0, cellsMatrix: [[0]])
+            return Level(id: id, cellsMatrix: [[0]])
         }
 
         var correctSize = size % 2 == 0 ? size : size + 1
@@ -34,7 +34,7 @@ final class LevelGenerator: ILevelGenerator {
         let maxAttempts = maxUniqueLevels(for: correctSize)
 
         guard existingLevels.count < maxAttempts else {
-            return Level(id: 0, cellsMatrix: [[0]])
+            return Level(id: id, cellsMatrix: [[0]])
         }
 
         var level: Level

--- a/Project/Sources/Views/ViewModels/GameViewModel.swift
+++ b/Project/Sources/Views/ViewModels/GameViewModel.swift
@@ -44,7 +44,7 @@ final class GameViewModel: ObservableObject {
 		self.cells = GameViewModel.mapCells(gameManager.game.level.cellsMatrix)
 		self.taps = gameManager.game.taps.count
 		self.isLevelCompleted = false
-		self.isTutorialLevel = gameManager.game.level.id == 0
+		self.isTutorialLevel = gameManager.game.level.isTutorial
 	}
 
 	func cellTapped(atX x: Int, atY y: Int) {
@@ -66,14 +66,11 @@ final class GameViewModel: ObservableObject {
 	func nextLevel() {
         gameManager.nextLevel(size: 2)
 		updateViewModel()
-		isTutorialLevel = game.level.id == 0
-		isLevelCompleted = false
 	}
 
 	func restartLevel() {
 		gameManager.restartLevel()
 		updateViewModel()
-		isLevelCompleted = false
 	}
 
 	func getHint() {
@@ -122,7 +119,6 @@ final class GameViewModel: ObservableObject {
 	func eraserButtonTapped() {
 		Task {
 			gameManager.resetProgress()
-//			await gameManager.updateGame()
 			updateViewModel()
 		}
 	}
@@ -140,6 +136,6 @@ final class GameViewModel: ObservableObject {
 		self.cells = GameViewModel.mapCells(game.level.cellsMatrix)
 		self.taps = game.taps.count
 		self.isLevelCompleted = false
-		self.isTutorialLevel = gameManager.game.level.id == 0
+		self.isTutorialLevel = gameManager.game.level.isTutorial
 	}
 }

--- a/Project/Tests/GameManagerTests.swift
+++ b/Project/Tests/GameManagerTests.swift
@@ -208,6 +208,17 @@ final class GameManagerTests: XCTestCase {
         )
     }
 
+    func test_nextLevel_shouldPassSequentialIdsToGenerator() {
+        sut.nextLevel(size: 2)
+        XCTAssertEqual(mockLevelGenerator.lastGeneratedId, 1, "Expected generated id to be 1")
+
+        sut.nextLevel(size: 2)
+        XCTAssertEqual(mockLevelGenerator.lastGeneratedId, 2, "Expected generated id to be 2")
+
+        sut.nextLevel(size: 2)
+        XCTAssertEqual(mockLevelGenerator.lastGeneratedId, 3, "Expected generated id to be 3")
+    }
+
 	// MARK: - Restart Level
 
 	func test_restartLevel_shouldResetStateToInitial() {

--- a/Project/Tests/LevelGeneratorTests.swift
+++ b/Project/Tests/LevelGeneratorTests.swift
@@ -110,14 +110,14 @@ final class LevelGeneratorTests: XCTestCase {
         XCTAssertEqual(level.levelSize, 2, "Expected size 1 to be rounded up to 2")
     }
 
-    func test_generateRandomLevel_withZeroSize_shouldReturnDefaultLevel() {
+    func test_generateRandomLevel_withZeroSize_shouldReturnDefaultLevelWithPassedId() {
         let level = sut.generateRandomLevel(
             id: 1,
             size: 0,
             existingLevels: []
         )
 
-        XCTAssertEqual(level.id, 0, "Expected default level with id 0")
+        XCTAssertEqual(level.id, 1, "Expected default level with id 1")
         XCTAssertEqual(level.cellsMatrix, [[0]], "Expected default matrix [[0]]")
     }
 
@@ -128,7 +128,7 @@ final class LevelGeneratorTests: XCTestCase {
             existingLevels: []
         )
 
-        XCTAssertEqual(level.id, 0, "Expected default level with id 0")
+        XCTAssertEqual(level.id, 1, "Expected default level with id 1")
         XCTAssertEqual(level.cellsMatrix, [[0]], "Expected default matrix [[0]]")
     }
 
@@ -177,7 +177,7 @@ final class LevelGeneratorTests: XCTestCase {
             existingLevels: existingLevels
         )
 
-        XCTAssertEqual(level.id, 0, "Expected default level when all variants exhausted")
+        XCTAssertEqual(level.id, 15, "Expected default level to keep passed id when all variants are exhausted")
         XCTAssertEqual(level.cellsMatrix, [[0]], "Expected default matrix [[0]]")
     }
 }


### PR DESCRIPTION
- fallback levels now keep passed id instead of resetting to 0
- updated LevelGeneratorTests expectations
- added GameManager tests for sequential id generation